### PR TITLE
Add Markstream

### DIFF
--- a/600-open-source-projects-notion.csv
+++ b/600-open-source-projects-notion.csv
@@ -609,3 +609,4 @@
 608,Kodi,Self-hosted / Personal,Open-source home theater software.,https://github.com/xbmc/xbmc,To Review,Curated GitHub list
 609,Fail2ban,Security / Auth,Protect servers from brute-force attacks.,https://github.com/fail2ban/fail2ban,To Review,Curated GitHub list
 610,MapServer,Maps / Geo,Web mapping server for publishing spatial data.,https://github.com/MapServer/MapServer,To Review,Curated GitHub list
+611,Markstream,Design / Frontend,Streaming Markdown renderer for AI chat across major web frameworks.,https://github.com/Simon-He95/markstream-vue,To Review,Curated GitHub list

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ The full list is also available as [`600-open-source-projects-notion.csv`](600-o
 | 564 | [Quickwit](https://github.com/quickwit-oss/quickwit) | Search engine for logs and traces |
 | 566 | [Tantivy](https://github.com/quickwit-oss/tantivy) | Full-text search engine library |
 | 603 | [Excalidraw](https://github.com/excalidraw/excalidraw) | Virtual whiteboard for sketching hand-drawn diagrams. |
+| 611 | [Markstream](https://github.com/Simon-He95/markstream-vue) | Streaming Markdown renderer for AI chat across major web frameworks. |
 
 ## AI / ML
 


### PR DESCRIPTION
Adds [Markstream](https://github.com/Simon-He95/markstream-vue) to **Design / Frontend** and keeps the Notion CSV in sync.

It fits the list because it is an MIT-licensed, actively maintained streaming Markdown renderer for AI chat interfaces, with packages for Vue, React, Svelte, and Angular. The description stays under the requested length.

Thanks for maintaining the collection!